### PR TITLE
Allows custom factory

### DIFF
--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -11,3 +11,14 @@ describe('Post', function () {
     test()->toBeUpdate();
     test()->toBeDelete();
 });
+
+describe('Custom factory', function () {
+    beforeEach()->eloquent(Post::class);
+    beforeEach()->factory(fn ($factory) => $factory->state([
+        'title' => 'Laravel Tester',
+    ]));
+
+    test()->toBeCreate()->assertDatabaseHas(Post::class, [
+        'title' => 'Laravel Tester',
+    ]);
+});

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Workbench\App\Models\Post;
 
 describe('Eloquent', function () {
@@ -14,7 +15,7 @@ describe('Eloquent', function () {
 
 describe('Custom factory', function () {
     beforeEach()->eloquent(Post::class);
-    beforeEach()->factory(fn ($factory) => $factory->state([
+    beforeEach()->factory(fn (Factory $factory) => $factory->state([
         'title' => 'Laravel Tester',
     ]));
 

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Workbench\App\Models\Post;
 
-describe('Post', function () {
+describe('Eloquent', function () {
     beforeEach()->eloquent(Post::class);
 
     test()->toBeCreate();


### PR DESCRIPTION
Allows a custom factory to be used in testing.

```php
use Illuminate\Database\Eloquent\Factories\Factory;

describe('Custom factory', function () {
    beforeEach()->eloquent(Post::class);

    // Customize the factory state
    beforeEach()->factory(fn (Factory $factory) => $factory->state([
        'title' => 'Laravel Tester',
    ]));

    // That will affect the result
    test()->toBeCreate()->assertDatabaseHas(Post::class, [
        'title' => 'Laravel Tester',
    ]);
});

```

Important to know that `Laravel Tester` use [Model and Factory Discovery Conventions](https://laravel.com/docs/11.x/eloquent-factories#factory-and-model-discovery-conventions).