### PR TITLE
Ensures `toBeDelete` works when using soft deletes

### DIFF
--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Workbench\App\Models\Post;
+use Workbench\App\Models\User;
 
 describe('Eloquent', function () {
     beforeEach()->eloquent(Post::class);
@@ -22,4 +23,10 @@ describe('Custom factory', function () {
     test()->toBeCreate()->assertDatabaseHas(Post::class, [
         'title' => 'Laravel Tester',
     ]);
+});
+
+describe('Soft deletes', function () {
+    beforeEach()->eloquent(User::class);
+
+    test()->toBeDelete();
 });

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -6,10 +6,12 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Model
 {
     use HasFactory;
+    use SoftDeletes;
 
     protected $table = 'user';
 

--- a/workbench/database/migrations/0000_00_00_000000_create_user_table.php
+++ b/workbench/database/migrations/0000_00_00_000000_create_user_table.php
@@ -14,6 +14,7 @@ class CreateUserTable extends Migration
             $table->id();
             $table->string('name');
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 


### PR DESCRIPTION
Ensures model that uses `SoftDeletes` can be tested by  `toBeDelete`.

```php
class User extends Model
{
    // ..
    use SoftDeletes;
    // ..
}

describe('Soft deletes', function () {
    beforeEach()->eloquent(User::class);

    test()->toBeDelete();
});
```