### PR TITLE
Allows testing `belongsTo` relation

### DIFF
--- a/src/Relation.php
+++ b/src/Relation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dex\Pest\Plugin\Laravel\Tester;
+
+trait Relation
+{
+    use Eloquent;
+
+    public function toHaveBelongsToRelation(string $class, string $relation)
+    {
+        $model = $this->factory->create();
+
+        $this->assertInstanceOf($class, $model->getAttribute($relation));
+        $this->assertDatabaseCount($model->getTable(), 1);
+        $this->assertDatabaseCount($class, 1);
+
+        return test();
+    }
+}

--- a/src/Tester.php
+++ b/src/Tester.php
@@ -12,4 +12,5 @@ use Illuminate\Foundation\Testing\TestCase;
 trait Tester
 {
     use Eloquent;
+    use Relation;
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -30,3 +30,9 @@ describe('Soft deletes', function () {
 
     test()->toBeDelete();
 });
+
+describe('Relation', function () {
+    beforeEach()->eloquent(Post::class);
+
+    test()->toHaveBelongsToRelation(User::class, 'user');
+});

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -6,6 +6,7 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Post extends Model
 {
@@ -14,4 +15,12 @@ class Post extends Model
     protected $table = 'post';
 
     protected $fillable = ['user_id', 'title'];
+
+    /**
+     * @return BelongsTo<User, self>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 }


### PR DESCRIPTION
Adds `toHaveBelongsToRelation()` method.

```php
class Post extends Model
{
   // ..
    public function user(): BelongsTo
    {
        return $this->belongsTo(User::class);
    }
   // ..
}


describe('Relation', function () {
    beforeEach()->eloquent(Post::class);

    test()->toHaveBelongsToRelation(User::class, 'user');
});
```