### PR TITLE
Allows testing `hasMany` relation

### DIFF
--- a/src/Relation.php
+++ b/src/Relation.php
@@ -18,4 +18,16 @@ trait Relation
 
         return test();
     }
+
+    public function toHaveHasManyRelation(string $class, string $relation)
+    {
+        $model = $this->factory
+            ->has($class::factory(), $relation)
+            ->create();
+
+        $this->assertContainsOnlyInstancesOf($class, $model->getAttribute($relation));
+        $this->assertCount(1, $model->getAttribute($relation));
+
+        return test();
+    }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Comment;
 use Workbench\App\Models\Post;
 use Workbench\App\Models\User;
 
@@ -35,4 +36,5 @@ describe('Relation', function () {
     beforeEach()->eloquent(Post::class);
 
     test()->toHaveBelongsToRelation(User::class, 'user');
+    test()->toHaveHasManyRelation(Comment::class, 'comments');
 });

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -7,6 +7,7 @@ namespace Workbench\App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Post extends Model
 {
@@ -22,5 +23,13 @@ class Post extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<Comment>
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
     }
 }


### PR DESCRIPTION
Adds `toHaveHasManyRelation()` method.

```php
class Post extends Model
{
   // ..
    public function comments(): HasMany
    {
        return $this->hasMany(Comment::class);
    }
   // ..
}


describe('Relation', function () {
    beforeEach()->eloquent(Post::class);

    test()->toHaveHasManyRelation(Comment::class, 'comments');
});
```