### PR TITLE
Allows testing `hasOne` relation

### DIFF
--- a/src/Relation.php
+++ b/src/Relation.php
@@ -30,4 +30,15 @@ trait Relation
 
         return test();
     }
+
+    public function toHaveHasOneRelation(string $class, string $relation)
+    {
+        $model = $this->factory
+            ->has($class::factory(), $relation)
+            ->create();
+
+        $this->assertInstanceOf($class, $model->getAttribute($relation));
+
+        return test();
+    }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -37,4 +37,5 @@ describe('Relation', function () {
 
     test()->toHaveBelongsToRelation(User::class, 'user');
     test()->toHaveHasManyRelation(Comment::class, 'comments');
+    test()->toHaveHasOneRelation(Comment::class, 'latestComment');
 });

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Post extends Model
 {
@@ -31,5 +32,13 @@ class Post extends Model
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * @return HasOne<Comment>
+     */
+    public function latestComment(): HasOne
+    {
+        return $this->hasOne(Comment::class);
     }
 }


### PR DESCRIPTION
Adds `toHaveHasOneRelation()` method.

```php
class Post extends Model
{
   // ..
    public function latestComment(): HasOne
    {
        return $this->hasOne(Comment::class);
    }
   // ..
}


describe('Relation', function () {
    beforeEach()->eloquent(Post::class);

    test()->toHaveHasOneRelation(Comment::class, 'latestComment');
});
```