### PR TITLE
Allows to test API resources endpoints

### DIFF
--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -17,6 +17,15 @@ trait Endpoint
         return $this;
     }
 
+    public function toHaveIndexEndpoint()
+    {
+        $models = $this->factory->count(3)->create();
+
+        return $this->getJson($this->endpoint)
+            ->assertOk()
+            ->assertJson($models->toArray());
+    }
+
     public function toHaveStoreEndpoint()
     {
         $modelAttributes = $this->factory->make()->toArray();

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -27,4 +27,20 @@ trait Endpoint
 
         return $response;
     }
+
+    public function toHaveUpdateEndpoint()
+    {
+        $modelCreated = $this->factory->create();
+        $modelUpdateAttributes = $this->factory->make()->toArray();
+
+        $response = $this->putJson($this->endpoint.'/'.$modelCreated->getKey(), $modelUpdateAttributes)
+            ->assertOk()
+            ->assertJson($modelUpdateAttributes);
+
+        $this->assertDatabaseMissing($modelCreated->getTable(), $this->removeTimestamps($modelCreated->getAttributes()));
+        $this->assertDatabaseHas($modelCreated->getTable(), $this->removeTimestamps($modelUpdateAttributes));
+        $this->assertDatabaseCount($modelCreated->getTable(), 1);
+
+        return $response;
+    }
 }

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dex\Pest\Plugin\Laravel\Tester;
+
+trait Endpoint
+{
+    private string $endpoint;
+
+    public function endpoint(string $endpoint): static
+    {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+}

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -39,6 +39,15 @@ trait Endpoint
         return $response;
     }
 
+    public function toHaveShowEndpoint()
+    {
+        $modelCreated = $this->factory->create();
+
+        return $this->getJson($this->endpoint.'/'.$modelCreated->getKey())
+            ->assertOk()
+            ->assertJson($modelCreated->getAttributes());
+    }
+
     public function toHaveUpdateEndpoint()
     {
         $modelCreated = $this->factory->create();

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 trait Endpoint
 {
+    use Eloquent;
+
     private string $endpoint;
 
     public function endpoint(string $endpoint): static
@@ -45,7 +47,9 @@ trait Endpoint
 
         return $this->getJson($this->endpoint.'/'.$modelCreated->getKey())
             ->assertOk()
-            ->assertJson($modelCreated->getAttributes());
+            ->assertJson(
+                $this->removeTimestamps($modelCreated->getAttributes())
+            );
     }
 
     public function toHaveUpdateEndpoint()

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -14,4 +14,17 @@ trait Endpoint
 
         return $this;
     }
+
+    public function toHaveStoreEndpoint()
+    {
+        $modelAttributes = $this->factory->make()->toArray();
+
+        $response = $this->postJson($this->endpoint, $modelAttributes)
+            ->assertCreated()
+            ->assertJson($modelAttributes);
+
+        $this->assertDatabaseCount($this->class, 1);
+
+        return $response;
+    }
 }

--- a/src/Tester.php
+++ b/src/Tester.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Testing\TestCase;
  */
 trait Tester
 {
+    use Endpoint;
     use Eloquent;
     use Relation;
 }

--- a/src/Tester.php
+++ b/src/Tester.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\TestCase;
  */
 trait Tester
 {
-    use Endpoint;
     use Eloquent;
+    use Endpoint;
     use Relation;
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -48,3 +48,10 @@ describe('Endpoint', function () {
     test()->toHaveUpdateEndpoint();
     test()->toHaveDestroyEndpoint();
 });
+
+describe('Endpoint and soft deletes', function () {
+    beforeEach()->eloquent(User::class);
+    beforeEach()->endpoint('/api/user');
+
+    test()->toHaveDestroyEndpoint();
+});

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -46,4 +46,5 @@ describe('Endpoint', function () {
 
     test()->toHaveStoreEndpoint();
     test()->toHaveUpdateEndpoint();
+    test()->toHaveDestroyEndpoint();
 });

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -45,4 +45,5 @@ describe('Endpoint', function () {
     beforeEach()->endpoint('/api/post');
 
     test()->toHaveStoreEndpoint();
+    test()->toHaveUpdateEndpoint();
 });

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -44,6 +44,7 @@ describe('Endpoint', function () {
     beforeEach()->eloquent(Post::class);
     beforeEach()->endpoint('/api/post');
 
+    test()->toHaveIndexEndpoint();
     test()->toHaveStoreEndpoint();
     test()->toHaveUpdateEndpoint();
     test()->toHaveDestroyEndpoint();

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -39,3 +39,10 @@ describe('Relation', function () {
     test()->toHaveHasManyRelation(Comment::class, 'comments');
     test()->toHaveHasOneRelation(Comment::class, 'latestComment');
 });
+
+describe('Endpoint', function () {
+    beforeEach()->eloquent(Post::class);
+    beforeEach()->endpoint('/api/post');
+
+    test()->toHaveStoreEndpoint();
+});

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -46,6 +46,7 @@ describe('Endpoint', function () {
 
     test()->toHaveIndexEndpoint();
     test()->toHaveStoreEndpoint();
+    test()->toHaveShowEndpoint();
     test()->toHaveUpdateEndpoint();
     test()->toHaveDestroyEndpoint();
 });

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -13,4 +13,14 @@ class PostController
     {
         return Post::query()->create($request->all());
     }
+
+    public function update(Request $request, string $id)
+    {
+        $model = Post::query()->findOrFail($id);
+
+        $model->fill($request->all());
+        $model->save();
+
+        return $model;
+    }
 }

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -23,4 +23,13 @@ class PostController
 
         return $model;
     }
+
+    public function destroy(string $id)
+    {
+        $model = Post::query()->findOrFail($id);
+
+        $model->delete();
+
+        return $model;
+    }
 }

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Workbench\App\Models\Post;
+
+class PostController
+{
+    public function store(Request $request)
+    {
+        return Post::query()->create($request->all());
+    }
+}

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -19,6 +19,11 @@ class PostController
         return Post::query()->create($request->all());
     }
 
+    public function show(string $id)
+    {
+        return Post::query()->findOrFail($id);
+    }
+
     public function update(Request $request, string $id)
     {
         $model = Post::query()->findOrFail($id);

--- a/workbench/app/Http/Controllers/PostController.php
+++ b/workbench/app/Http/Controllers/PostController.php
@@ -9,6 +9,11 @@ use Workbench\App\Models\Post;
 
 class PostController
 {
+    public function index()
+    {
+        return Post::query()->get();
+    }
+
     public function store(Request $request)
     {
         return Post::query()->create($request->all());

--- a/workbench/app/Http/Controllers/UserController.php
+++ b/workbench/app/Http/Controllers/UserController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Http\Controllers;
+
+use Workbench\App\Models\User;
+
+class UserController
+{
+    public function destroy(string $id)
+    {
+        $model = User::query()->findOrFail($id);
+
+        $model->delete();
+
+        return $model;
+    }
+}

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -16,7 +16,7 @@ class Post extends Model
 
     protected $table = 'post';
 
-    protected $fillable = ['user_id', 'title'];
+    protected $fillable = ['user_id', 'title', 'content'];
 
     /**
      * @return BelongsTo<User, self>

--- a/workbench/routes/api.php
+++ b/workbench/routes/api.php
@@ -4,5 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Workbench\App\Http\Controllers\PostController;
+use Workbench\App\Http\Controllers\UserController;
 
 Route::apiResource('/api/post', PostController::class);
+Route::apiResource('/api/user', UserController::class);

--- a/workbench/routes/api.php
+++ b/workbench/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Workbench\App\Http\Controllers\PostController;
+
+Route::apiResource('/api/post', PostController::class);


### PR DESCRIPTION
Allows to test [Eloquent: API Resources](https://laravel.com/docs/11.x/eloquent-resources) endpoints.

```php
describe('Endpoint', function () {
    beforeEach()->eloquent(Post::class);
    beforeEach()->endpoint('/api/post');

    test()->toHaveIndexEndpoint();
    test()->toHaveStoreEndpoint();
    test()->toHaveShowEndpoint();
    test()->toHaveUpdateEndpoint();
    test()->toHaveDestroyEndpoint();
});
```