### PR TITLE
Uses random strings to validate `min` rule

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -35,7 +35,7 @@ trait Validator
     {
         $modelAttributes = $this->factory->make()->toArray();
 
-        $modelAttributes[$attribute] = substr((string) $modelAttributes[$attribute], 0, $min - 1);
+        $modelAttributes[$attribute] = Str::random($min - 1);
 
         $this->postJson($this->endpoint, $modelAttributes)
             ->assertUnprocessable()


### PR DESCRIPTION
Ensures that the string will always be the correct length.